### PR TITLE
Change XC-20 functions' modifiers

### DIFF
--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -145,7 +145,13 @@ where
                         | Action::Transfer
                         | Action::TransferFrom
                         | Action::Mint
-                        | Action::Burn => FunctionModifier::NonPayable,
+                        | Action::Burn
+                        | Action::Freeze
+                        | Action::Thaw
+                        | Action::FreezeAsset
+                        | Action::ThawAsset
+                        | Action::TransferOwnership
+                        | Action::SetTeam => FunctionModifier::NonPayable,
                         _ => FunctionModifier::View,
                     }) {
                         return Some(Err(err));

--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -144,6 +144,7 @@ where
                         Action::Approve
                         | Action::Transfer
                         | Action::TransferFrom
+                        | Action::ForceTransfer
                         | Action::Mint
                         | Action::Burn
                         | Action::Freeze


### PR DESCRIPTION
with this PR merged the following functions will have modifier `non-payable` instead of `view`:
- `forceTransfer`
- `freeze`
- `thaw`
- `freezeAsset`
- `thawAsset`
- `transferOwnership`
- `setTeam`